### PR TITLE
Fix too short field length issue

### DIFF
--- a/database/migrations/create_xhprof_table.php.stub
+++ b/database/migrations/create_xhprof_table.php.stub
@@ -39,6 +39,12 @@ class CreateXHProfTable extends Migration
             $table->index('timestamp');
             $table->index(['server name', 'timestamp']);
         });
+        
+        if(DB::connection()->getDriverName() === 'mysql') {
+            DB::statement('ALTER TABLE details MODIFY COLUMN `perfdata` LONGBLOB');
+            DB::statement('ALTER TABLE details MODIFY COLUMN `cookie` LONGBLOB');
+            DB::statement('ALTER TABLE details MODIFY COLUMN `post` LONGBLOB');
+        }
     }
 
     /**


### PR DESCRIPTION
In some cases, the collected data is more than 65 KB, which is the default for MySQL BLOB data.  There is no other built-in way to define LONGBLOB in Laravel 9, so I just use raw statements.

This PR fixes the error for new migrations.