### PR TITLE
fix(middleware): Prevent include on json requests

### DIFF
--- a/src/Middleware/XHProfMiddleware.php
+++ b/src/Middleware/XHProfMiddleware.php
@@ -30,7 +30,11 @@ class XHProfMiddleware
             //to start profiling, just enable it immediately
             $_COOKIE['_profile'] = 1;
 
-            require_once public_path(). '/vendor/xhprof/external/header.php';
+            // Only include if request does not expect JSON.
+            // Not using $request->excpectsJson or $rquest->wantsJson to work with Livewire because Livewire only set content-type header to json.
+            if ($request->header('content-type') !== 'application/json') {
+                require_once public_path(). '/vendor/xhprof/external/header.php';
+            }
         }
 
         return $next($request);


### PR DESCRIPTION
This PR to only include if request does not expect JSON.

I'm not using `$request->excpectsJson` or `$rquest->wantsJson` to work with **Livewire** (because Livewire only set content-type header to json.)