### PR TITLE
Allow to skip specific urls given a needle.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -2,4 +2,10 @@
 
 return [
     'enabled' => env('XHPROF_ENABLED', false),
+
+    // Allow to skip profiling for some URIs
+    'skip' => [
+		'/__clockwork/',
+		'/_debugbar/',
+	],
 ];

--- a/src/Middleware/XHProfMiddleware.php
+++ b/src/Middleware/XHProfMiddleware.php
@@ -23,6 +23,12 @@ class XHProfMiddleware
                 throw new Exception('xhprof is enabled but extension is not installed or disabled! Please install or enable xhprof extension!');
             }
 
+            foreach (config('xhprof.skip', []) as $skip) {
+                if (str_contains($request->url(), $skip)) {
+                    return $next($request);
+                }
+            }
+
             //this needs to be declared as global!
             global $_xhprof;
 


### PR DESCRIPTION
When using xhprof, I noticed that the display were polluted with all the requests to debugbar & clockwork.
This fix allows to skip those request (and reduce the noise on what we wish to measure). 